### PR TITLE
Correcting the URL and folder name in the 'How to run' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The notebook is designed to be launched from Binder.
 You may also download the notebook from GitHub to run it locally:
 * Open your terminal
 * Check your conda install with `conda --version`. If you don't have conda, install it by following these instructions (see [here](https://docs.conda.io/en/latest/miniconda.html))
-* Clone the repository, `https://github.com/scivision-gallery/treecrown-detection_detectreeRGB.git` 
-* Move into the cloned repository, `cd treecrown-detection_detectreeRGB`
-* Install the dependencies, `conda env create -f environment.yml`
+* Clone the repository into your current folder `git clone https://github.com/scivision-gallery/tree-crown-detection` 
+* Move into the cloned repository, `cd tree-crown-detection`
+* Install the dependencies in a new environment `conda env create -f environment.yml`
 * Activate the installed environment, `conda activate treecrown-detection_detectreeRGB`
 * Launch the jupyter interface of your preference, notebook, `jupyter notebook` or lab `jupyter lab`
 


### PR DESCRIPTION
The url link was incorrect, so following the "How to run" instructions produced an error.